### PR TITLE
Wrap tauri command into `async`

### DIFF
--- a/src-tauri/src/audio/audio_handler.rs
+++ b/src-tauri/src/audio/audio_handler.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, io::Read};
 
-#[tauri::command]
+#[tauri::command(async)]
 pub fn get_audio_data(file_path: String) -> Result<String, String> {
     let mut file = File::open(&file_path)
         .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Fixes #37 

Running this command asynchronously allows us to continue running the application without blocking the thread.